### PR TITLE
Add file reference identifier

### DIFF
--- a/Sources/xcproj/PBXFileReference.swift
+++ b/Sources/xcproj/PBXFileReference.swift
@@ -7,6 +7,9 @@ final public class PBXFileReference: PBXFileElement {
  
     // MARK: - Attributes
     
+    /// Element reference identifier
+    public var reference: String?
+    
     /// Element file encoding.
     public var fileEncoding: UInt?
     
@@ -35,6 +38,7 @@ final public class PBXFileReference: PBXFileElement {
     /// - Parameters:
     ///   - sourceTree: file source tree.
     ///   - name: file name.
+    ///   - reference: file identifier.
     ///   - fileEncoding: text encoding of file content.
     ///   - explicitFileType: user-specified file type.
     ///   - lastKnownFileType: derived file type.
@@ -50,6 +54,7 @@ final public class PBXFileReference: PBXFileElement {
     ///   - plistStructureDefinitionIdentifier: the plist organizational family identifier.
     public init(sourceTree: PBXSourceTree? = nil,
                 name: String? = nil,
+                reference: String? = nil,
                 fileEncoding: UInt? = nil,
                 explicitFileType: String? = nil,
                 lastKnownFileType: String? = nil,
@@ -63,6 +68,7 @@ final public class PBXFileReference: PBXFileElement {
                 languageSpecificationIdentifier: String? = nil,
                 xcLanguageSpecificationIdentifier: String? = nil,
                 plistStructureDefinitionIdentifier: String? = nil) {
+        self.reference = reference
         self.fileEncoding = fileEncoding
         self.explicitFileType = explicitFileType
         self.lastKnownFileType = lastKnownFileType
@@ -83,6 +89,7 @@ final public class PBXFileReference: PBXFileElement {
     // MARK: - Decodable
     
     fileprivate enum CodingKeys: String, CodingKey {
+        case reference
         case fileEncoding
         case explicitFileType
         case lastKnownFileType
@@ -94,6 +101,7 @@ final public class PBXFileReference: PBXFileElement {
     
     public required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.reference = try container.decodeIfPresent(.reference)
         self.fileEncoding = try container.decodeIntIfPresent(.fileEncoding)
         self.explicitFileType = try container.decodeIfPresent(.explicitFileType)
         self.lastKnownFileType = try container.decodeIfPresent(.lastKnownFileType)

--- a/Tests/xcprojTests/PBXFileReferenceSpec.swift
+++ b/Tests/xcprojTests/PBXFileReferenceSpec.swift
@@ -10,6 +10,7 @@ final class PBXFileReferenceSpec: XCTestCase {
         super.setUp()
         subject = PBXFileReference(sourceTree: .absolute,
                                    name: "name",
+                                   reference: "DB260A3A-043E-40AD-8B48-EAA69E7B31F5",
                                    fileEncoding: 1,
                                    explicitFileType: "type",
                                    lastKnownFileType: "last",
@@ -19,6 +20,7 @@ final class PBXFileReferenceSpec: XCTestCase {
     func test_init_initializesTheReferenceWithTheRightAttributes() {
         XCTAssertEqual(subject.name, "name")
         XCTAssertEqual(subject.sourceTree, .absolute)
+        XCTAssertEqual(subject.reference, "DB260A3A-043E-40AD-8B48-EAA69E7B31F5")
         XCTAssertEqual(subject.fileEncoding, 1)
         XCTAssertEqual(subject.explicitFileType, "type")
         XCTAssertEqual(subject.lastKnownFileType, "last")
@@ -32,6 +34,7 @@ final class PBXFileReferenceSpec: XCTestCase {
     func test_equal_returnsTheCorrectValue() {
         let another = PBXFileReference(sourceTree: .absolute,
                                        name: "name",
+                                       reference: "DB260A3A-043E-40AD-8B48-EAA69E7B31F5",
                                        fileEncoding: 1,
                                        explicitFileType: "type",
                                        lastKnownFileType: "last",


### PR DESCRIPTION
### Short description 📝

The file reference identifier may have been present in earlier versions of xcproj but was no longer exposed. This value is valuable for matching up files to specific references in other places in the project.

e.g. getting the variantGroup that includes localizable `Localizable.strings` and then iterating the `fileReferences` to match up the file that matches the `Localizable.strings` variant by reference identifier.

### Solution 📦

I could see that the codable container for included `reference` but that for some reason is was no longer being exposed by `PBXFileReference` or any of its superclasses.

### Implementation 👩‍💻👨‍💻

- [ ] Add the optional `reference` property to `PBXFileReference`, including codable conformance
- [ ] Include `reference` in the `PBXFileReferenceSpec`

