### PR TITLE
Make KeyedDecodingContainer functions internal

### DIFF
--- a/Sources/xcodeproj/KeyedDecodingContainer+Additions.swift
+++ b/Sources/xcodeproj/KeyedDecodingContainer+Additions.swift
@@ -1,29 +1,29 @@
 import Foundation
 
 extension KeyedDecodingContainer {
-    public func decode<T>(_ key: KeyedDecodingContainer.Key) throws -> T where T: Decodable {
+    func decode<T>(_ key: KeyedDecodingContainer.Key) throws -> T where T: Decodable {
         return try decode(T.self, forKey: key)
     }
 
-    public func decodeIfPresent<T>(_ key: KeyedDecodingContainer.Key) throws -> T? where T: Decodable {
+    func decodeIfPresent<T>(_ key: KeyedDecodingContainer.Key) throws -> T? where T: Decodable {
         return try decodeIfPresent(T.self, forKey: key)
     }
 
-    public func decodeIntIfPresent(_ key: KeyedDecodingContainer.Key) throws -> UInt? {
+    func decodeIntIfPresent(_ key: KeyedDecodingContainer.Key) throws -> UInt? {
         guard let string: String = try decodeIfPresent(key) else {
             return nil
         }
         return UInt(string)
     }
 
-    public func decodeIntBool(_ key: KeyedDecodingContainer.Key) throws -> Bool {
+    func decodeIntBool(_ key: KeyedDecodingContainer.Key) throws -> Bool {
         guard let int = try decodeIntIfPresent(key) else {
             return false
         }
         return int == 1
     }
 
-    public func decodeIntBoolIfPresent(_ key: KeyedDecodingContainer.Key) throws -> Bool? {
+    func decodeIntBoolIfPresent(_ key: KeyedDecodingContainer.Key) throws -> Bool? {
         guard let int = try decodeIntIfPresent(key) else {
             return nil
         }


### PR DESCRIPTION
This fixes cases where a codebase already has these functions or is pulling in a library that explicitly adds these (like https://github.com/yonaskolb/Codability).
Without this change the Swift compiler fails with `Ambiguous use of 'decode'`